### PR TITLE
Fixed: Prevented duplicate custom entry types from overwriting existing ones

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://files.jabref.org/gradle-9.3.0-jabref-2-bin.zip
+distributionUrl=https://files.jabref.org/gradle-9.5.0-jabref-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=false
 zipStoreBase=GRADLE_USER_HOME

--- a/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTabViewModel.java
@@ -72,14 +72,13 @@ public class CustomEntryTypesTabViewModel implements PreferenceTabViewModel {
         this.multiLineFields.addAll(preferences.getFieldPreferences().getNonWrappableFields());
 
         entryTypeValidator = new FunctionBasedValidator<>(
-                entryTypeToAdd,
-                input -> StringUtil.isNotBlank(input) && !input.contains(" "),
-                ValidationMessage.error(Localization.lang("Entry type cannot be empty and must not contain spaces.")));
+                                                          entryTypeToAdd,
+                                                          input -> StringUtil.isNotBlank(input) && !input.contains(" "),
+                                                          ValidationMessage.error(Localization.lang("Entry type cannot be empty and must not contain spaces.")));
         fieldValidator = new FunctionBasedValidator<>(
-                newFieldToAdd,
-                input -> StringUtil.isNotBlank(input) && !input.contains(" "),
-                ValidationMessage.error(Localization.lang("Field cannot be empty. Please enter a name."))
-        );
+                                                      newFieldToAdd,
+                                                      input -> StringUtil.isNotBlank(input) && !input.contains(" "),
+                                                      ValidationMessage.error(Localization.lang("Field cannot be empty. Please enter a name.")));
     }
 
     @Override
@@ -136,10 +135,33 @@ public class CustomEntryTypesTabViewModel implements PreferenceTabViewModel {
         preferences.storeCustomEntryTypesRepository(entryTypesManager);
     }
 
+    // public EntryTypeViewModel addNewCustomEntryType() {
+    //     EntryType newentryType = new UnknownEntryType(entryTypeToAdd.getValue());
+    //     BibEntryType type = new BibEntryType(newentryType, new ArrayList<>(), List.of());
+    //     EntryTypeViewModel viewModel = new CustomEntryTypeViewModel(type, isMultiline);
+    //     this.entryTypesWithFields.add(viewModel);
+    //     this.entryTypeToAdd.setValue("");
+
+    //     return viewModel;
+    // }
+
     public EntryTypeViewModel addNewCustomEntryType() {
-        EntryType newentryType = new UnknownEntryType(entryTypeToAdd.getValue());
+        String newName = entryTypeToAdd.getValue().trim();
+
+        boolean exists = entryTypesWithFields.stream()
+                                             .anyMatch(type -> type.entryType().getValue().getType().getName().equalsIgnoreCase(newName));
+
+        if (exists) {
+            dialogService.showWarningDialogAndWait(
+                                                   "Duplicate entry type",
+                                                   "An entry type with this name already exists.");
+            return null;
+        }
+
+        EntryType newentryType = new UnknownEntryType(newName);
         BibEntryType type = new BibEntryType(newentryType, new ArrayList<>(), List.of());
         EntryTypeViewModel viewModel = new CustomEntryTypeViewModel(type, isMultiline);
+
         this.entryTypesWithFields.add(viewModel);
         this.entryTypeToAdd.setValue("");
 
@@ -159,22 +181,21 @@ public class CustomEntryTypesTabViewModel implements PreferenceTabViewModel {
 
         if (fieldExists) {
             dialogService.showWarningDialogAndWait(
-                    Localization.lang("Duplicate fields"),
-                    Localization.lang("Warning: You added field \"%0\" twice. Only one will be kept.", FieldTextMapper.getDisplayName(newField)));
+                                                   Localization.lang("Duplicate fields"),
+                                                   Localization.lang("Warning: You added field \"%0\" twice. Only one will be kept.", FieldTextMapper.getDisplayName(newField)));
         } else {
             this.selectedEntryType.getValue().addField(new FieldViewModel(
-                    newField,
-                    FieldViewModel.Mandatory.REQUIRED,
-                    FieldPriority.IMPORTANT,
-                    false));
+                                                                          newField,
+                                                                          FieldViewModel.Mandatory.REQUIRED,
+                                                                          FieldPriority.IMPORTANT,
+                                                                          false));
         }
         newFieldToAdd.set("");
     }
 
     public boolean displayNameExists(String displayName) {
         ObservableList<FieldViewModel> entryFields = this.selectedEntryType.getValue().fields();
-        return entryFields.stream().anyMatch(fieldViewModel ->
-                fieldViewModel.displayNameProperty().getValue().equals(displayName));
+        return entryFields.stream().anyMatch(fieldViewModel -> fieldViewModel.displayNameProperty().getValue().equals(displayName));
     }
 
     public void removeField(FieldViewModel focusedItem) {


### PR DESCRIPTION
This pull request fixes the issue where saving a custom entry type with the same name overwrote an existing entry type.

A validation check was added in CustomEntryTypesTabViewModel.addNewCustomEntryType() to prevent duplicate names from being added.

Now, if a duplicate name is entered, a warning dialog is shown and the entry type is not added.
