### PR TITLE
Fix RIS export: split page ranges with -- double dash

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/layout/format/FirstPage.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/FirstPage.java
@@ -13,11 +13,18 @@ public class FirstPage implements LayoutFormatter {
         if (s == null) {
             return "";
         }
-        String[] pageParts = s.split("[ \\-]+");
+        //Replaces fancy characters as '-'
+        String normalized = s.trim()
+                             .replace('–', '-')
+                             .replace('—', '-');
+
+        //Splits the numbers in two parts, shows only first
+        String[] pageParts = normalized.split("\\s*-{1,2}\\s*", 2);
+
         if (pageParts.length == 2) {
-            return pageParts[0];
+            return pageParts[0].trim();
         } else {
-            return s;
+            return normalized;
         }
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/layout/format/LastPage.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/LastPage.java
@@ -13,11 +13,18 @@ public class LastPage implements LayoutFormatter {
         if (s == null) {
             return "";
         }
-        String[] pageParts = s.split("[\\-]+");
+        //Replaces fancy characters as '-'
+        String normalized = s.trim()
+                             .replace('–', '-')
+                             .replace('—', '-');
+        //Splits in two parts
+
+        String[] pageParts = normalized.split("\\s*-{1,2}\\s*", 2);
+        //Returns Second part as last page
         if (pageParts.length == 2) {
-            return pageParts[1];
+            return pageParts[1].trim();
         } else if (pageParts.length >= 1) {
-            return pageParts[0];
+            return normalized;
         } else {
             return "";
         }


### PR DESCRIPTION
Related issues and pull requests

#12

## PR Description
Fix RIS export so page ranges written with a double dash (`--`) are correctly split into SP and EP.

## Steps to test
1. Create or import a BibTeX entry where `pages` contains a range using `--` (e.g., `10--12`).
2. Export the entry to RIS.
3. Verify the RIS output contains correct `SP` (start page) and `EP` (end page).
<img width="675" height="424" alt="git" src="https://github.com/user-attachments/assets/db085ecc-52be-4ff8-83da-7a34e5944348" />

## Checklist
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added JUnit tests for changes (if applicable)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in CHANGELOG.md in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository
