### PR TITLE
WIP: sync with main; The icon bug is still reproducible and not fixed yet.  

### DIFF
--- a/jabgui/buildres/windows/overrides.wxi
+++ b/jabgui/buildres/windows/overrides.wxi
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?define WixUIBannerBmp="JabRefTopBanner.bmp"?>
+  <?define WixUIDialogBmp="JabRefDialog.bmp"?>
+</Include>


### PR DESCRIPTION
I synced my branch with `main` and verified there are currently no merge conflicts.  
The icon bug is still reproducible and not fixed yet.  
I’m continuing investigation in the Windows installer files (`main.wxs` / `overrides.wxi`) and will push another update with the actual fix.