### PR TITLE
Fix #7: Resolved bug where New Entry dialog opens too small (Original Repo Issue id: #11589)

### DIFF
--- a/jabgui/src/main/resources/org/jabref/gui/newentry/NewEntry.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/newentry/NewEntry.fxml
@@ -18,7 +18,11 @@
 <?import javafx.scene.layout.TilePane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
-<DialogPane xmlns:fx="http://javafx.com/fxml/1" prefWidth="600"
+<DialogPane xmlns:fx="http://javafx.com/fxml/1"
+            prefWidth="850"
+            prefHeight="700"
+            minWidth="850"
+            minHeight="700"
         xmlns="http://javafx.com/javafx/8.0.171"
         fx:controller="org.jabref.gui.newentry.NewEntryView">
     <content>


### PR DESCRIPTION
### Related issues and pull requests

Closes #7  


### PR Description

Updated the root layout constraints in NewEntry.fxml to increase the default dialog size. This ensures that all entry type categories including “Other” and “Non-standard” types in BibLaTeX mode  are fully visible when the dialog opens, without requiring manual resizing.

Previously, the dialog opened too small, causing some entry types to be hidden. This change restores the intended user experience and ensures consistent layout behavior across screen resolutions.

### Steps to test

1. Open JabRef and ensure you are working in a BibLaTeX library (check Library > Library properties).
2. Go to the top menu and select Library > New entry Using (second option) or Click the "+" (Plus icon) in the toolbar.
3. The "Select entry type" dialog will pop up.
4. Observe that the window now pops up with a larger default size (850x700).
5. Verify that the "Non-standard types" section at the bottom is fully visible without having to drag the window corners to manually resize to view all entry types.

Before :
<img width="596" height="756" alt="image" src="https://github.com/user-attachments/assets/deb13286-bf07-4f48-9170-3dbc8dc8217c" />

After :
<img width="1919" height="1016" alt="image_2026-02-16_18-56-11" src="https://github.com/user-attachments/assets/fe934219-56c6-4ac1-a7c2-ccd315e95e68" />

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added JUnit tests for changes (if applicable)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)