### PR TITLE
Removed unused variable initialDir

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/integrity/BibLogSettingsPane.java
+++ b/jabgui/src/main/java/org/jabref/gui/integrity/BibLogSettingsPane.java
@@ -71,7 +71,6 @@ public class BibLogSettingsPane {
     }
 
     private FileDialogConfiguration createBlgFileDialogConfig() {
-        Path initialDir = viewModel.getInitialDirectory();
         FileDialogConfiguration config = new FileDialogConfiguration.Builder()
                 .addExtensionFilter(Localization.lang("BibTeX log files"), StandardFileType.BLG)
                 .withDefaultExtension(Localization.lang("BibTeX log files"), StandardFileType.BLG)


### PR DESCRIPTION
### Related issues and pull requests

Closes [Issue #29](https://github.com/rilling/jabref/issues/29)

### PR Description

The issue that this solves is the removal of unused variable initialDir from the BibLogSettingPane.java file.
Path: abgui/src/main/java/org/jabref/gui/integrity/BibLogSettingsPane.java

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
