### PR TITLE
Fix SonarQube S2095 resource leak bugs

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/biblog/BibtexLogParser.java
+++ b/jablib/src/main/java/org/jabref/logic/biblog/BibtexLogParser.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.jabref.model.biblog.BibWarning;
 import org.jabref.model.biblog.SeverityType;
@@ -25,10 +26,11 @@ public class BibtexLogParser {
     private static final String MULTI_INVALID_FIELD_PREFIX = "field - one of '";
 
     public List<BibWarning> parseBiblog(@NonNull Path blgFilePath) throws IOException {
-        return Files.lines(blgFilePath)
-                    .map(this::parseWarningLine)
-                    .flatMap(Optional::stream)
-                    .toList();
+        try (Stream<String> lines = Files.lines(blgFilePath)) {
+            return lines.map(this::parseWarningLine)
+                        .flatMap(Optional::stream)
+                        .toList();
+        }
     }
 
     /// Parses a single line from a .blg file to identify a warning.

--- a/jablib/src/main/java/org/jabref/logic/util/MscCodeUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/util/MscCodeUtils.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.util;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
@@ -29,9 +30,9 @@ public class MscCodeUtils {
     public static Optional<HashBiMap<String, String>> loadMscCodesFromJson(URL resourceUrl) throws MscCodeLoadingException {
 
         ObjectMapper mapper = new JsonMapper();
-        try {
+        try (InputStream inputStream = resourceUrl.openStream()) {
             Map<String, String> mapping =
-                    mapper.readValue(resourceUrl.openStream(), new TypeReference<>() {
+                    mapper.readValue(inputStream, new TypeReference<>() {
                     });
             HashBiMap<String, String> result = HashBiMap.create(mapping);
 


### PR DESCRIPTION
Closes https://github.com/rilling/jabref/issues/38

## PR Description

Fixes two BLOCKER resource leak bugs reported by SonarQube rule `java:S2095` ("Resources should be closed"). In `MscCodeUtils.java`, the `InputStream` from `resourceUrl.openStream()` was passed inline and never closed on exception. In `BibtexLogParser.java`, the `Stream<String>` from `Files.lines()` was consumed but never closed, leaking the underlying file handle. Both are now wrapped in `try-with-resources` to guarantee cleanup.

## Steps to test

1. Open JabRef and import a library that triggers MSC code lookup (e.g., a math-related `.bib` file). Verify MSC codes still resolve correctly — this exercises `MscCodeUtils.loadMscCodesFromJson()`.
2. Open a `.bib` project that has an associated `.blg` log file. Verify that bibliography warnings from the log are still parsed and displayed — this exercises `BibtexLogParser.parseBiblog()`.
3. Run existing unit tests for both classes to confirm no regressions: `./gradlew test --tests "org.jabref.logic.util.*" --tests "org.jabref.logic.biblog.*"`

## Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en).