### PR TITLE
Fix: Add 'since' and 'forRemoval' arguments to @Deprecated annotation in CliImportHelper.java

### DIFF
--- a/jabgui/src/main/java/org/jabref/cli/CliImportHelper.java
+++ b/jabgui/src/main/java/org/jabref/cli/CliImportHelper.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 ///  CLI import helper that are needed for importing stuff from the browser extension
 ///
 /// @deprecated used by the browser extension only
-@Deprecated
+@Deprecated(since = "5.13", forRemoval = true)
 public class CliImportHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(CliImportHelper.class);
 


### PR DESCRIPTION
### Related issues and pull requests
Closes https://github.com/rilling/jabref/issues/33

## PR Description
Added 'since' and 'forRemoval' arguments to the @Deprecated annotation in CliImportHelper.java. 
The annotation was missing these arguments which is required to clearly indicate the version 
since deprecation and whether the method is planned for removal.
Path: jabgui/src/main/java/org/jabref/cli/CliImportHelper.java

* [X] I own the copyright of the code submitted and I license it under the MIT license
* [ ] I manually tested my changes in running JabRef (always required)
* [ ] I added JUnit tests for changes (if applicable)
* [ ] I added screenshots in the PR description (if change is visible to the user)
* [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
* [ ] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
* [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository

