### PR TITLE
Fix: Remove code clone by extracting shared test methods into AbstractAutoCompleterTest

### DIFF
--- a/jabgui/src/test/java/org/jabref/gui/autocompleter/AbstractAutoCompleterTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/autocompleter/AbstractAutoCompleterTest.java
@@ -1,0 +1,107 @@
+package org.jabref.gui.autocompleter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.jabref.gui.autocompleter.AutoCompleterUtil.getRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+abstract class AbstractAutoCompleterTest {
+
+    protected SuggestionProvider<String> autoCompleter;
+    protected BibDatabase database;
+
+    @BeforeEach
+    void setUp() {
+        database = new BibDatabase();
+        autoCompleter = createAutoCompleter();
+    }
+
+    protected abstract SuggestionProvider<String> createAutoCompleter();
+
+    @Test
+    void completeWithoutAddingAnythingReturnsNothing() {
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    void completeAfterAddingEmptyEntryReturnsNothing() {
+        BibEntry entry = new BibEntry();
+        database.insertEntry(entry);
+
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    void completeAfterAddingEntryWithoutFieldReturnsNothing() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.AUTHOR, "testAuthor");
+        database.insertEntry(entry);
+
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    void completeValueReturnsValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.TITLE, "testValue");
+        database.insertEntry(entry);
+
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testValue"));
+        assertEquals(List.of("testValue"), result);
+    }
+
+    @Test
+    void completeLowercaseValueReturnsValue() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.TITLE, "testValue");
+        database.insertEntry(entry);
+
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testvalue"));
+        assertEquals(List.of("testValue"), result);
+    }
+
+    @Test
+    void completeNullThrowsException() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.TITLE, "testKey");
+        database.insertEntry(entry);
+
+        assertThrows(NullPointerException.class, () -> autoCompleter.provideSuggestions(getRequest(null)));
+    }
+
+    @Test
+    void completeEmptyStringReturnsNothing() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.TITLE, "testKey");
+        database.insertEntry(entry);
+
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(""));
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    void completeReturnsMultipleResults() {
+        BibEntry entryOne = new BibEntry();
+        entryOne.setField(StandardField.TITLE, "testValueOne");
+        database.insertEntry(entryOne);
+        BibEntry entryTwo = new BibEntry();
+        entryTwo.setField(StandardField.TITLE, "testValueTwo");
+        database.insertEntry(entryTwo);
+
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testValue"));
+        assertEquals(Arrays.asList("testValueOne", "testValueTwo"), result);
+    }
+}

--- a/jabgui/src/test/java/org/jabref/gui/autocompleter/DefaultAutoCompleterTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/autocompleter/DefaultAutoCompleterTest.java
@@ -1,64 +1,21 @@
 package org.jabref.gui.autocompleter;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.jabref.gui.autocompleter.AutoCompleterUtil.getRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class DefaultAutoCompleterTest {
+class DefaultAutoCompleterTest extends AbstractAutoCompleterTest {
 
-    private WordSuggestionProvider autoCompleter;
-    private BibDatabase database;
-
-    @BeforeEach
-    void setUp() {
-        database = new BibDatabase();
-        autoCompleter = new WordSuggestionProvider(StandardField.TITLE, database);
-    }
-
-    @Test
-    void completeWithoutAddingAnythingReturnsNothing() {
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
-        assertEquals(List.of(), result);
-    }
-
-    @Test
-    void completeAfterAddingEmptyEntryReturnsNothing() {
-        BibEntry entry = new BibEntry();
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
-        assertEquals(List.of(), result);
-    }
-
-    @Test
-    void completeAfterAddingEntryWithoutFieldReturnsNothing() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.AUTHOR, "testAuthor");
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
-        assertEquals(List.of(), result);
-    }
-
-    @Test
-    void completeValueReturnsValue() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.TITLE, "testValue");
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testValue"));
-        assertEquals(List.of("testValue"), result);
+    @Override
+    protected SuggestionProvider<String> createAutoCompleter() {
+        return new WordSuggestionProvider(StandardField.TITLE, database);
     }
 
     @Test
@@ -69,48 +26,6 @@ class DefaultAutoCompleterTest {
 
         Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
         assertEquals(List.of("testValue"), result);
-    }
-
-    @Test
-    void completeLowercaseValueReturnsValue() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.TITLE, "testValue");
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testvalue"));
-        assertEquals(List.of("testValue"), result);
-    }
-
-    @Test
-    void completeNullThrowsException() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.TITLE, "testKey");
-        database.insertEntry(entry);
-
-        assertThrows(NullPointerException.class, () -> autoCompleter.provideSuggestions(getRequest(null)));
-    }
-
-    @Test
-    void completeEmptyStringReturnsNothing() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.TITLE, "testKey");
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest(""));
-        assertEquals(List.of(), result);
-    }
-
-    @Test
-    void completeReturnsMultipleResults() {
-        BibEntry entryOne = new BibEntry();
-        entryOne.setField(StandardField.TITLE, "testValueOne");
-        database.insertEntry(entryOne);
-        BibEntry entryTwo = new BibEntry();
-        entryTwo.setField(StandardField.TITLE, "testValueTwo");
-        database.insertEntry(entryTwo);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testValue"));
-        assertEquals(Arrays.asList("testValueOne", "testValueTwo"), result);
     }
 
     @Test

--- a/jabgui/src/test/java/org/jabref/gui/autocompleter/FieldValueSuggestionProviderTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/autocompleter/FieldValueSuggestionProviderTest.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.autocompleter;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -8,53 +7,21 @@ import java.util.Set;
 import javafx.collections.FXCollections;
 
 import org.jabref.logic.journals.JournalAbbreviationRepository;
-import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.jabref.gui.autocompleter.AutoCompleterUtil.getRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class FieldValueSuggestionProviderTest {
+class FieldValueSuggestionProviderTest extends AbstractAutoCompleterTest {
 
-    private FieldValueSuggestionProvider autoCompleter;
-    private BibDatabase database;
-
-    @BeforeEach
-    void setUp() {
-        database = new BibDatabase();
-        autoCompleter = new FieldValueSuggestionProvider(StandardField.TITLE, database);
-    }
-
-    @Test
-    void completeWithoutAddingAnythingReturnsNothing() {
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
-        assertEquals(List.of(), result);
-    }
-
-    @Test
-    void completeAfterAddingEmptyEntryReturnsNothing() {
-        BibEntry entry = new BibEntry();
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
-        assertEquals(List.of(), result);
-    }
-
-    @Test
-    void completeAfterAddingEntryWithoutFieldReturnsNothing() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.AUTHOR, "testAuthor");
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
-        assertEquals(List.of(), result);
+    @Override
+    protected SuggestionProvider<String> createAutoCompleter() {
+        return new FieldValueSuggestionProvider(StandardField.TITLE, database);
     }
 
     @Test
@@ -75,16 +42,6 @@ class FieldValueSuggestionProviderTest {
     }
 
     @Test
-    void completeValueReturnsValue() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.TITLE, "testValue");
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testValue"));
-        assertEquals(List.of("testValue"), result);
-    }
-
-    @Test
     void completeBeginnigOfValueReturnsValue() {
         BibEntry entry = new BibEntry();
         entry.setField(StandardField.TITLE, "testValue");
@@ -92,48 +49,6 @@ class FieldValueSuggestionProviderTest {
 
         Collection<String> result = autoCompleter.provideSuggestions(getRequest("test"));
         assertEquals(List.of("testValue"), result);
-    }
-
-    @Test
-    void completeLowercaseValueReturnsValue() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.TITLE, "testValue");
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testvalue"));
-        assertEquals(List.of("testValue"), result);
-    }
-
-    @Test
-    void completeNullThrowsException() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.TITLE, "testKey");
-        database.insertEntry(entry);
-
-        assertThrows(NullPointerException.class, () -> autoCompleter.provideSuggestions(getRequest(null)));
-    }
-
-    @Test
-    void completeEmptyStringReturnsNothing() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.TITLE, "testKey");
-        database.insertEntry(entry);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest(""));
-        assertEquals(List.of(), result);
-    }
-
-    @Test
-    void completeReturnsMultipleResults() {
-        BibEntry entryOne = new BibEntry();
-        entryOne.setField(StandardField.TITLE, "testValueOne");
-        database.insertEntry(entryOne);
-        BibEntry entryTwo = new BibEntry();
-        entryTwo.setField(StandardField.TITLE, "testValueTwo");
-        database.insertEntry(entryTwo);
-
-        Collection<String> result = autoCompleter.provideSuggestions(getRequest("testValue"));
-        assertEquals(Arrays.asList("testValueOne", "testValueTwo"), result);
     }
 
     @Test


### PR DESCRIPTION
Closes #59

## PR Description
CPD (PMD Clone Detector) detected a 53 line (301 tokens) duplication between:
- DefaultAutoCompleterTest.java (line 65)
- FieldValueSuggestionProviderTest.java (line 88)

Fix: Created AbstractAutoCompleterTest.java as an abstract base class containing 
the 8 shared test methods. Both DefaultAutoCompleterTest and 
FieldValueSuggestionProviderTest now extend this base class, eliminating the duplication.

* [X] I own the copyright of the code submitted and I license it under the MIT license
* [x] I manually tested my changes in running JabRef (always required)
* [x] I added JUnit tests for changes (if applicable)
* [x] I added screenshots in the PR description (if change is visible to the user)
* [ ] I described the change in CHANGELOG.md (if change is visible to the user)