### PR TITLE
Refactor duplicated logic in GetCitedWorks and GetCitingWorks

### DIFF
--- a/jabkit/src/main/java/org/jabref/toolkit/commands/CitationCommandHelper.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/CitationCommandHelper.java
@@ -1,0 +1,63 @@
+package org.jabref.toolkit.commands;
+
+import java.util.List;
+
+import org.jabref.logic.ai.AiService;
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.fetcher.citation.CitationFetcher;
+import org.jabref.logic.importer.fetcher.citation.CitationFetcherType;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.logic.util.CurrentThreadTaskExecutor;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import org.slf4j.Logger;
+
+final class CitationCommandHelper {
+
+    private CitationCommandHelper() {
+    }
+
+    static int fetchAndOutputEntries(JabKit argumentProcessor,
+                                     CitationFetcherType citationFetcherType,
+                                     String doi,
+                                     Logger logger,
+                                     boolean fetchCitations) {
+        CliPreferences preferences = argumentProcessor.cliPreferences;
+
+        AiService aiService = new AiService(
+                preferences.getAiPreferences(),
+                preferences.getFilePreferences(),
+                preferences.getCitationKeyPatternPreferences(),
+                logger::info,
+                new CurrentThreadTaskExecutor());
+
+        CitationFetcher citationFetcher = CitationFetcherType.getCitationFetcher(
+                citationFetcherType,
+                preferences.getImporterPreferences(),
+                preferences.getImportFormatPreferences(),
+                preferences.getCitationKeyPatternPreferences(),
+                preferences.getGrobidPreferences(),
+                aiService
+        );
+
+        List<BibEntry> entries;
+
+        try {
+            BibEntry entry = new BibEntry().withField(StandardField.DOI, doi);
+            entries = fetchCitations
+                      ? citationFetcher.getCitations(entry)
+                      : citationFetcher.getReferences(entry);
+        } catch (FetcherException e) {
+            logger.error("Could not fetch citation information based on DOI", e);
+            System.err.print(Localization.lang("No data was found for the identifier"));
+            System.err.println(" - " + doi);
+            System.err.println(e.getLocalizedMessage());
+            System.err.println();
+            return 2;
+        }
+
+        return JabKit.outputEntries(argumentProcessor.cliPreferences, entries);
+    }
+}

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/GetCitedWorks.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/GetCitedWorks.java
@@ -1,17 +1,8 @@
 package org.jabref.toolkit.commands;
 
-import java.util.List;
 import java.util.concurrent.Callable;
 
-import org.jabref.logic.ai.AiService;
-import org.jabref.logic.importer.FetcherException;
-import org.jabref.logic.importer.fetcher.citation.CitationFetcher;
 import org.jabref.logic.importer.fetcher.citation.CitationFetcherType;
-import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.preferences.CliPreferences;
-import org.jabref.logic.util.CurrentThreadTaskExecutor;
-import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.field.StandardField;
 import org.jabref.toolkit.converter.CitationFetcherTypeConverter;
 
 import org.slf4j.Logger;
@@ -42,36 +33,12 @@ class GetCitedWorks implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        CliPreferences preferences = argumentProcessor.cliPreferences;
-        AiService aiService = new AiService(
-                preferences.getAiPreferences(),
-                preferences.getFilePreferences(),
-                preferences.getCitationKeyPatternPreferences(),
-                LOGGER::info,
-                new CurrentThreadTaskExecutor());
-
-        CitationFetcher citationFetcher = CitationFetcherType.getCitationFetcher(
+        return CitationCommandHelper.fetchAndOutputEntries(
+                argumentProcessor,
                 citationFetcherType,
-                preferences.getImporterPreferences(),
-                preferences.getImportFormatPreferences(),
-                preferences.getCitationKeyPatternPreferences(),
-                preferences.getGrobidPreferences(),
-                aiService
+                doi,
+                LOGGER,
+                false
         );
-
-        List<BibEntry> entries;
-
-        try {
-            entries = citationFetcher.getReferences(new BibEntry().withField(StandardField.DOI, doi));
-        } catch (FetcherException e) {
-            LOGGER.error("Could not fetch citation information based on DOI", e);
-            System.err.print(Localization.lang("No data was found for the identifier"));
-            System.err.println(" - " + doi);
-            System.err.println(e.getLocalizedMessage());
-            System.err.println();
-            return 2;
-        }
-
-        return JabKit.outputEntries(argumentProcessor.cliPreferences, entries);
     }
 }

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/GetCitingWorks.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/GetCitingWorks.java
@@ -1,17 +1,8 @@
 package org.jabref.toolkit.commands;
 
-import java.util.List;
 import java.util.concurrent.Callable;
 
-import org.jabref.logic.ai.AiService;
-import org.jabref.logic.importer.FetcherException;
-import org.jabref.logic.importer.fetcher.citation.CitationFetcher;
 import org.jabref.logic.importer.fetcher.citation.CitationFetcherType;
-import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.preferences.CliPreferences;
-import org.jabref.logic.util.CurrentThreadTaskExecutor;
-import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.field.StandardField;
 import org.jabref.toolkit.converter.CitationFetcherTypeConverter;
 
 import org.slf4j.Logger;
@@ -42,36 +33,12 @@ class GetCitingWorks implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        CliPreferences preferences = argumentProcessor.cliPreferences;
-        AiService aiService = new AiService(
-                preferences.getAiPreferences(),
-                preferences.getFilePreferences(),
-                preferences.getCitationKeyPatternPreferences(),
-                LOGGER::info,
-                new CurrentThreadTaskExecutor());
-
-        CitationFetcher citationFetcher = CitationFetcherType.getCitationFetcher(
+        return CitationCommandHelper.fetchAndOutputEntries(
+                argumentProcessor,
                 citationFetcherType,
-                preferences.getImporterPreferences(),
-                preferences.getImportFormatPreferences(),
-                preferences.getCitationKeyPatternPreferences(),
-                preferences.getGrobidPreferences(),
-                aiService
+                doi,
+                LOGGER,
+                true
         );
-
-        List<BibEntry> entries;
-
-        try {
-            entries = citationFetcher.getCitations(new BibEntry().withField(StandardField.DOI, doi));
-        } catch (FetcherException e) {
-            LOGGER.error("Could not fetch citation information based on DOI", e);
-            System.err.print(Localization.lang("No data was found for the identifier"));
-            System.err.println(" - " + doi);
-            System.err.println(e.getLocalizedMessage());
-            System.err.println();
-            return 2;
-        }
-
-        return JabKit.outputEntries(argumentProcessor.cliPreferences, entries);
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/rilling/jabref/issues/69

### PR Description
This PR refactors duplicated command logic related to DOI-based citation fetching into a shared helper, reducing clone duplication while preserving the existing behavior. The change simplifies the command flow and improves maintainability for the toolkit commands.

### Steps to test

./gradlew :jabkit:test -x :jablib:generateLtwaListMV

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)