### PR TITLE
Refactor duplicated citation command formatting in BibLatexFormatter and NatbibFormatter

### DIFF
--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/format/AbstractCitationCommandFormatter.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/format/AbstractCitationCommandFormatter.java
@@ -1,0 +1,40 @@
+package org.jabref.http.server.cayw.format;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.jabref.http.server.cayw.CAYWQueryParams;
+import org.jabref.http.server.cayw.gui.CAYWEntry;
+import org.jabref.model.entry.BibEntry;
+
+import jakarta.ws.rs.core.MediaType;
+
+abstract class AbstractCitationCommandFormatter implements CAYWFormatter {
+
+    private final String defaultCommand;
+
+    protected AbstractCitationCommandFormatter(String defaultCommand) {
+        this.defaultCommand = defaultCommand;
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        return MediaType.TEXT_PLAIN_TYPE;
+    }
+
+    @Override
+    public String format(CAYWQueryParams queryParams, List<CAYWEntry> caywEntries) {
+        String command = queryParams.getCommand().orElse(defaultCommand);
+
+        List<BibEntry> bibEntries = caywEntries.stream()
+                                               .map(CAYWEntry::bibEntry)
+                                               .toList();
+
+        return "\\%s{%s}".formatted(command,
+                bibEntries.stream()
+                          .map(BibEntry::getCitationKey)
+                          .flatMap(Optional::stream)
+                          .collect(Collectors.joining(",")));
+    }
+}

--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/format/BibLatexFormatter.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/format/BibLatexFormatter.java
@@ -1,42 +1,11 @@
 package org.jabref.http.server.cayw.format;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import org.jabref.http.server.cayw.CAYWQueryParams;
-import org.jabref.http.server.cayw.gui.CAYWEntry;
-import org.jabref.model.entry.BibEntry;
-
-import jakarta.ws.rs.core.MediaType;
 import org.jvnet.hk2.annotations.Service;
 
 @Service
-public class BibLatexFormatter implements CAYWFormatter {
-
-    private final String defaultCommand;
+public class BibLatexFormatter extends AbstractCitationCommandFormatter {
 
     public BibLatexFormatter(String defaultCommand) {
-        this.defaultCommand = defaultCommand;
-    }
-
-    @Override
-    public MediaType getMediaType() {
-        return MediaType.TEXT_PLAIN_TYPE;
-    }
-
-    @Override
-    public String format(CAYWQueryParams queryParams, List<CAYWEntry> caywEntries) {
-        String command = queryParams.getCommand().orElse(defaultCommand);
-
-        List<BibEntry> bibEntries = caywEntries.stream()
-                                               .map(CAYWEntry::bibEntry)
-                                               .toList();
-
-        return "\\%s{%s}".formatted(command,
-                bibEntries.stream()
-                          .map(BibEntry::getCitationKey)
-                          .flatMap(Optional::stream)
-                          .collect(Collectors.joining(",")));
+        super(defaultCommand);
     }
 }

--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/format/NatbibFormatter.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/format/NatbibFormatter.java
@@ -1,42 +1,11 @@
 package org.jabref.http.server.cayw.format;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import org.jabref.http.server.cayw.CAYWQueryParams;
-import org.jabref.http.server.cayw.gui.CAYWEntry;
-import org.jabref.model.entry.BibEntry;
-
-import jakarta.ws.rs.core.MediaType;
 import org.jvnet.hk2.annotations.Service;
 
 @Service
-public class NatbibFormatter implements CAYWFormatter {
-
-    private final String defaultCommand;
+public class NatbibFormatter extends AbstractCitationCommandFormatter {
 
     public NatbibFormatter(String defaultCommand) {
-        this.defaultCommand = defaultCommand;
-    }
-
-    @Override
-    public MediaType getMediaType() {
-        return MediaType.TEXT_PLAIN_TYPE;
-    }
-
-    @Override
-    public String format(CAYWQueryParams queryParams, List<CAYWEntry> caywEntries) {
-        String command = queryParams.getCommand().orElse(defaultCommand);
-
-        List<BibEntry> bibEntries = caywEntries.stream()
-                                               .map(CAYWEntry::bibEntry)
-                                               .toList();
-
-        return "\\%s{%s}".formatted(command,
-                bibEntries.stream()
-                          .map(BibEntry::getCitationKey)
-                          .flatMap(Optional::stream)
-                          .collect(Collectors.joining(",")));
+        super(defaultCommand);
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes #70

### PR Description

This PR refactors duplicated logic in `BibLatexFormatter` and `NatbibFormatter` by extracting the shared citation command formatting into `AbstractCitationCommandFormatter`.

This PR removes duplicated code in `BibLatexFormatter` and `NatbibFormatter` with shared logic for:
- returning the media type
- resolving the command
- collecting citation keys
- building the final citation command string

has been extracted into `AbstractCitationCommandFormatter`.

This keeps the behavior unchanged while reducing duplication and making the formatter code easier to maintain.

### Steps to test

1. Run JabRef and verify it starts successfully.
2. Exercise the code path using `BibLatexFormatter` [jabsrv/src/main/java/org/jabref/http/server/cayw/format/BibLatexFormatter.java].
3. Exercise the code path using `NatbibFormatter` [jabsrv/src/main/java/org/jabref/http/server/cayw/format/NatbibFormatter.java].
4. Confirm the output format remains unchanged for both formatters.
5. Verify the refactoring does not introduce build or runtime issues.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license.
- [x] I manually tested my changes in running JabRef (always required).
- [ ] I added JUnit tests for changes (if applicable).
- [ ] I added screenshots in the PR description (if change is visible to the user).
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user).
- [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository.