### PR TITLE
Remove hardcoded password and use environment variable

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/net/ssl/TrustStoreManager.java
+++ b/jablib/src/main/java/org/jabref/logic/net/ssl/TrustStoreManager.java
@@ -30,7 +30,8 @@ import org.slf4j.LoggerFactory;
 public class TrustStoreManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TrustStoreManager.class);
-    private static final String STORE_PASSWORD = "changeit";
+
+   private static final String STORE_PASSWORD = System.getenv("STORE_PASSWORD") != null ? System.getenv("STORE_PASSWORD") : "";
 
     private final Path storePath;
 


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/rilling/jabref/issues/85 


### PR Description
Removed a hardcoded password from the SSL trust store configuration and replaced it with an environment variable lookup. This change improves security by keeping sensitive credentials out of the source code. The change preserves the intended functionality when the environment variable is properly configured.

### Steps to test
1. Open the project in IntelliJ IDEA.
2. Navigate to `TrustStoreManager`.
3. Verify that the hardcoded password has been removed and replaced with `System.getenv("STORE_PASSWORD")`.
4. Build the project and confirm that the code compiles successfully.
5. The change improves security by removing hardcoded credentials and follows secure coding best practices.


### Checklist

 
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
