### PR TITLE
Fix RCE vulnerability by upgrading scala-library to 2.13.9

### DIFF
--- a/jablib-examples/maven3/doi-to-bibtex/pom.xml
+++ b/jablib-examples/maven3/doi-to-bibtex/pom.xml
@@ -46,6 +46,14 @@
       <version>6.0-SNAPSHOT</version>
     </dependency>
 
+
+      <dependency>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-library</artifactId>
+          <version>2.13.9</version>
+      </dependency>
+
+
     <!-- JabRef relies on PR https://github.com/unicode-org/icu/pull/2127; for experiments the release version is OK -->
     <dependency>
       <groupId>com.ibm.icu</groupId>


### PR DESCRIPTION

### Related issues and pull requests

Closes https://github.com/rilling/jabref/issues/87

### PR Description

This change addresses a critical Remote Code Execution (RCE) vulnerability identified by Snyk in the transitive dependency `org.scala-lang:scala-library` (version 2.13.8), which is introduced through `jablib`.
The fix overrides the vulnerable dependency by explicitly declaring version `2.13.9` in the Maven `pom.xml`. This ensures that a secure version is used during dependency resolution.

<img width="2458" height="787" alt="Proof" src="https://github.com/user-attachments/assets/51b0354e-cbff-4cbd-9739-db74226ab7e5" />



### Steps to test

1. Navigate to `jablib-examples/maven3/doi-to-bibtex/pom.xml`.
2. Verify that `org.scala-lang:scala-library` is explicitly declared with version `2.13.9`.
3. In IntelliJ, open the Maven tool window and reload the project.
4. Expand the dependencies section and confirm that `scala-library` resolves to version `2.13.9`.
5. Compare with the Snyk report to confirm that version `2.13.8` was the vulnerable dependency.

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
