### PR TITLE
Fix vulnerability by upgrading jackson-core to 2.21.2

### DIFF
--- a/jablib-examples/maven3/doi-to-bibtex/pom.xml
+++ b/jablib-examples/maven3/doi-to-bibtex/pom.xml
@@ -53,6 +53,13 @@
       <version>78.2</version>
     </dependency>
 
+      <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+          <version>2.21.2</version>
+      </dependency>
+
+
     <dependency>
       <groupId>org.tinylog</groupId>
       <artifactId>tinylog-api</artifactId>


### PR DESCRIPTION
### Related issues and pull requests

Closes  https://github.com/rilling/jabref/issues/89


### PR Description
This change addresses a vulnerability in the transitive dependency `com.fasterxml.jackson.core:jackson-core` (version 2.21.1) identified by Snyk. The issue is resolved by adding version `2.21.2` in the `pom.xml` to override the vulnerable version.

### Steps to test
1. Open `jablib-examples/maven3/doi-to-bibtex/pom.xml`.
2. Verify that `jackson-core` is declared with version `2.21.2`.
3. In IntelliJ, reload the Maven project.
4. Check the dependencies and confirm that `jackson-core` resolves to version `2.21.2`.

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
