### PR TITLE
Modified hard coded password

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,7 +95,7 @@ sonar {
     }
 }
 
-tasks.named("sonarqube") {
+tasks.matching { it.name == "sonar" || it.name == "sonarqube" }.configureEach {
     onlyIf {
         System.getenv("SONAR_TOKEN") != null
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,6 @@ sonar {
 
 tasks.matching { it.name == "sonar" || it.name == "sonarqube" }.configureEach {
     onlyIf {
-        System.getenv("SONAR_TOKEN") != null
+        !System.getenv("SONAR_TOKEN").isNullOrBlank()
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/net/ssl/TrustStoreManager.java
+++ b/jablib/src/main/java/org/jabref/logic/net/ssl/TrustStoreManager.java
@@ -30,18 +30,27 @@ import org.slf4j.LoggerFactory;
 public class TrustStoreManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TrustStoreManager.class);
-    private static final String STORE_PASSWORD = "changeit";
+    private static final String STORE_PASSWORD_SYSTEM_PROPERTY = "javax.net.ssl.trustStorePassword";
+    private static final String STORE_PASSWORD_ENVIRONMENT_VARIABLE = "JABREF_TRUSTSTORE_PASSWORD";
 
     private final Path storePath;
 
     private KeyStore store;
+
+    private static char[] getStorePassword() {
+        String password = System.getProperty(STORE_PASSWORD_SYSTEM_PROPERTY);
+        if (password == null) {
+            password = System.getenv(STORE_PASSWORD_ENVIRONMENT_VARIABLE);
+        }
+        return password != null ? password.toCharArray() : null;
+    }
 
     public TrustStoreManager(Path storePath) {
         this.storePath = storePath;
         createTruststoreFileIfNotExist(storePath);
         try {
             store = KeyStore.getInstance(KeyStore.getDefaultType());
-            store.load(Files.newInputStream(storePath), STORE_PASSWORD.toCharArray());
+            store.load(Files.newInputStream(storePath), getStorePassword());
         } catch (CertificateException | IOException | NoSuchAlgorithmException | KeyStoreException e) {
             LOGGER.warn("Error while loading trust store from: {}", storePath.toAbsolutePath(), e);
         }
@@ -93,7 +102,7 @@ public class TrustStoreManager {
 
     public void flush() {
         try {
-            store.store(Files.newOutputStream(storePath), STORE_PASSWORD.toCharArray());
+            store.store(Files.newOutputStream(storePath), getStorePassword());
         } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
             LOGGER.warn("Error while flushing trust store", e);
         }
@@ -171,7 +180,7 @@ public class TrustStoreManager {
         // Adapt to load your keystore
         try (InputStream myKeys = Files.newInputStream(myStorePath)) {
             KeyStore myTrustStore = KeyStore.getInstance("jks");
-            myTrustStore.load(myKeys, STORE_PASSWORD.toCharArray());
+            myTrustStore.load(myKeys, getStorePassword());
 
             return findDefaultTrustManager(myTrustStore);
         }


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/rilling/jabref/issues/91 

### PR Description

- Removes a hard-coded truststore password and loads it from configuration (system property/env var).
- Fixes the SpotBugs/FindSecBugs `HARD_CODE_PASSWORD` finding.
- Minimal change intended to keep behavior consistent.

### Steps to test

 Run SpotBugs + FindSecBugs on `jablib.jar` and generate the HTML report.
 Confirm the report no longer contains `HARD_CODE_PASSWORD`.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)