### PR TITLE
Restrict overly permissive CORS origin handling

### DIFF
--- a/jabsrv/src/main/java/org/jabref/http/server/CORSFilter.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/CORSFilter.java
@@ -9,9 +9,15 @@ import jakarta.ws.rs.ext.Provider;
 public class CORSFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
-        responseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
-        responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-        responseContext.getHeaders().add("Access-Control-Allow-Headers", "origin, content-type, accept");
-        responseContext.getHeaders().add("Access-Control-Allow-Credentials", "false");
+        String origin = requestContext.getHeaderString("Origin");
+
+        // Allow only local origins (localhost or 127.0.0.1) with an optional port.
+        if (origin != null && origin.matches("^https?://(localhost|127\\.0\\.0\\.1)(:\\d+)?$")) {
+            responseContext.getHeaders().putSingle("Access-Control-Allow-Origin", origin);
+        }
+
+        responseContext.getHeaders().putSingle("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        responseContext.getHeaders().putSingle("Access-Control-Allow-Headers", "origin, content-type, accept");
+        responseContext.getHeaders().putSingle("Access-Control-Allow-Credentials", "false");
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes #96

### PR Description

This PR fixes an overly permissive CORS policy in `CORSFilter` by removing the wildcard origin setting and restricting allowed origins to local requests only.

Previously, the server responded with:

- `Access-Control-Allow-Origin: *`

This allowed requests from any origin and made the CORS policy too permissive.

This PR updates `CORSFilter` so that:
- the incoming `Origin` header is read from the request
- only local origins (`localhost` or `127.0.0.1`) with an optional port are allowed
- response headers are set using `putSingle(...)` for cleaner header handling

This improves origin validation and reduces the attack surface while keeping the change small and localized.

### Steps to test

1. Run `.\gradlew.bat :jabsrv:test` and verify the tests pass successfully.
2. Start the server and send a request with `Origin: http://localhost:8080`.
3. Confirm that the response includes `Access-Control-Allow-Origin` set to the same local origin.
4. Send a request with a non-local origin.
5. Confirm that wildcard origin access is no longer allowed.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license.
- [x] I manually tested my changes in running JabRef (always required).
- [ ] I added JUnit tests for changes (if applicable).
- [ ] I added screenshots in the PR description (if change is visible to the user).
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user).
- [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository.