### PR TITLE
Fix CVE-2022-36944 (Critical, CVSS 9.8) by forcing scala-library from 2.13.8 to 2.13.9.

### DIFF
--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -35,6 +35,12 @@ configurations.antlr {
     extendsFrom(configurations.internal.get())
 }
 
+configurations.all {
+    resolutionStrategy {
+        force("org.scala-lang:scala-library:2.13.9")
+    }
+}
+
 configurations {
     // Treat the ANTLR compiler as a separate tool that should not end up on the compile/runtime
     // classpath of our runtime.


### PR DESCRIPTION
## Problem
Snyk identified a critical Remote Code Execution (RCE) vulnerability in org.scala-lang:scala-library@2.13.8, which is pulled in as a transitive dependency through com.github.tomtung:latex2unicode_2.13@0.3.2. The vulnerability allows arbitrary code execution via LazyList object deserialization (CWE-94).
## Fix
Added a resolutionStrategy.force in jablib/build.gradle.kts to override the transitive scala-library version from 2.13.8 to 2.13.9. Version 2.13.9 is a patch release that removes the vulnerable deserialization gadget while maintaining full backward compatibility.
## Snyk Reference

Snyk ID: SNYK-JAVA-ORGSCALALANG-3032987
CVE: CVE-2022-36944
Severity: Critical (CVSS 9.8)
Fixed in: org.scala-lang:scala-library@2.13.9