### PR TITLE
Aman   vulnerability fix

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:4.0.2
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=en_US.UTF-8

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,7 +1,5 @@
 FROM ruby:4.0.2
 
-RUN apt-get update && apt-get upgrade -y
-
 ENV LC_ALL=C.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:4.0.2
 
+RUN apt-get update && apt-get upgrade -y
+
 ENV LC_ALL=C.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
@@ -110,7 +110,7 @@ public class EntryResource {
         BibDatabaseContext databaseContext = getDatabaseContext(id);
         List<BibEntry> entriesByCitationKey = databaseContext.getDatabase().getEntriesByCitationKey(entryId);
         if (entriesByCitationKey.isEmpty()) {
-            throw new NotFoundException("Entry with citation key '" + entryId + "' not found in library " + id);
+            throw new NotFoundException("Requested entry was not found.");
         }
 
         // 1. Determine BibEntry


### PR DESCRIPTION
## Fix Integer Overflow Vulnerability in libtiff-dev

### Description
This pull request addresses a high severity integer overflow vulnerability identified by Snyk in the `libtiff-dev` package.

### Issue
The vulnerability originates from the base image `ruby:4.0.2`, which includes an outdated version of `libtiff-dev`. Since this dependency is not explicitly managed in the Dockerfile, it is introduced indirectly and cannot be upgraded directly.

### Solution
To mitigate the issue, system packages were updated to ensure that patched versions of dependencies are installed.

### Changes Made
- Added system update and upgrade command in `docs/Dockerfile`:

dockerfile
RUN apt-get update && apt-get upgrade -y


### Impact
This change ensures that vulnerable packages are updated to secure versions, reducing the risk associated with integer overflow vulnerabilities.

### Reference
Snyk vulnerability report for `libtiff-dev`

The fixes made:
- Added proper line breaks between sections so headings render correctly
- Closed the unclosed dockerfile code block
- Added the missing `###` prefix to **Impact** and **Reference** so they render as headings instead of plain text