### PR TITLE
Remove hardcoded password pattern in ProxyTest

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/net/ProxyTest.java
+++ b/jablib/src/test/java/org/jabref/logic/net/ProxyTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.net;
-
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
+
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,7 +17,7 @@ class ProxyTest {
         String port = "8080";
         boolean useAuthentication = true;
         String username = "testUserName";
-        String password = "testPassword";
+        String password = UUID.randomUUID().toString();
         boolean persist = false;
 
         // Creates proxy preference


### PR DESCRIPTION
### Related issues and pull requests

Closes #102

### PR Description

This PR removes a hardcoded password-style value flagged by Snyk Code in `ProxyTest.java`. The test setup was updated to use a generated value instead, preserving the original test behavior while avoiding a hardcoded password pattern.

### Steps to test

./gradlew :jablib:test --tests org.jabref.logic.net.ProxyTest -x :jablib:generateLtwaListMV
## Checklist
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added JUnit tests for changes (if applicable)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in CHANGELOG.md in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository
