### PR TITLE
fix: Deserialization of Untrusted Data in remote Protocol (CWE-502)

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/remote/Protocol.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/Protocol.java
@@ -1,12 +1,16 @@
 package org.jabref.logic.remote;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.net.Socket;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 
 import javafx.util.Pair;
 
@@ -20,6 +24,37 @@ public class Protocol implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Protocol.class);
 
+    /**
+     * Whitelist of class names permitted during deserialization.
+     * Restricts Java object deserialization to the expected protocol types only,
+     * preventing CWE-502 (Deserialization of Untrusted Data).
+     */
+    private static final Set<String> ALLOWED_CLASSES = Set.of(
+            RemoteMessage.class.getName(),
+            String.class.getName(),
+            String[].class.getName()
+    );
+
+    /**
+     * A whitelist-enforcing ObjectInputStream that rejects any class not explicitly
+     * permitted, mitigating unsafe deserialization (CWE-502 / Snyk SNYK-CODE).
+     */
+    private static class SafeObjectInputStream extends ObjectInputStream {
+        SafeObjectInputStream(InputStream in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        protected Class<?> resolveClass(ObjectStreamClass desc)
+                throws IOException, ClassNotFoundException {
+            if (!ALLOWED_CLASSES.contains(desc.getName())) {
+                throw new InvalidClassException(
+                        "Unauthorized deserialization attempt blocked", desc.getName());
+            }
+            return super.resolveClass(desc);
+        }
+    }
+
     private final Socket socket;
     private final ObjectOutputStream out;
     private final ObjectInputStream in;
@@ -27,7 +62,7 @@ public class Protocol implements AutoCloseable {
     public Protocol(Socket socket) throws IOException {
         this.socket = socket;
         this.out = new ObjectOutputStream(socket.getOutputStream());
-        this.in = new ObjectInputStream(socket.getInputStream());
+        this.in = new SafeObjectInputStream(socket.getInputStream());
     }
 
     public void sendMessage(RemoteMessage type) throws IOException {


### PR DESCRIPTION
## Summary

Fixes the **Deserialization of Untrusted Data** (CWE-502) vulnerability flagged by Snyk in the JabRef remote listener protocol.

- Replaces the raw `ObjectInputStream` with a `SafeObjectInputStream` inner class that overrides `resolveClass()` to whitelist only the three expected types: `RemoteMessage`, `String`, and `String[]`.
- Any deserialization attempt for a class outside the whitelist throws `InvalidClassException` immediately, blocking gadget-chain attacks that could lead to Remote Code Execution.
- No wire-protocol changes — all existing remote communication tests pass unchanged.

**Snyk findings addressed:**
| Severity | File | Score |
|----------|------|-------|
| HIGH | `RemoteListenerServer.java` line 38 | 757 |
| MEDIUM | `Protocol.java` line 30 | 507 |

Closes #104

## Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://tldrlegal.com/license/mit-license)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation)